### PR TITLE
Fix CI deps and font import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install backend deps
         run: |
           cd backend
-          pip install django djangorestframework
+          pip install -r requirements.txt
       - name: Backend tests
         run: |
           cd backend

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,5 @@
 import './globals.css';
-import { Inter } from '@next/font/google';
+import { Inter } from 'next/font/google';
 import React from 'react';
 
 const inter = Inter({ subsets: ['latin'] });


### PR DESCRIPTION
## Summary
- correct Next font import path
- install all backend deps in CI

## Testing
- `pytest -q`
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a089a1e4c8320bdda998f39cbc96a